### PR TITLE
Changes record command to save

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -9,7 +9,7 @@ A Rust-based command-line tool to save, view, and run command snippets (primaril
 **Goal:** Save and run named shell commands from a YAML file.
 
 ### Features:
-- `record <name>`: Start an interactive session to save a multi-line bash command.
+- `save <name>`: Start an interactive session to save a multi-line bash command.
 - `run <name>`: Execute the stored command.
 - `list`: Show a simple table of stored commands (name + description).
 - `show <name>`: Print the full saved command.
@@ -33,7 +33,7 @@ A Rust-based command-line tool to save, view, and run command snippets (primaril
 ### Features:
 - Support `executable: true/false` flag in YAML.
 - `copy <name>`: Copy snippet to clipboard (via `arboard` or `copypasta`).
-- `record <name> --type snippet`: Save a snippet that won't be executed.
+- `save <name> --type snippet`: Save a snippet that won't be executed.
 - `list-full`: Show all metadata and full content.
 
 ---


### PR DESCRIPTION
### TL;DR

Renamed the `record` command to `save` in the roadmap documentation.

### What changed?

Updated the roadmap.md file to replace all instances of the `record` command with `save`:
- Changed `record <name>` to `save <name>` in the MVP features section
- Changed `record <name> --type snippet` to `save <name> --type snippet` in the v0.2 features section

### How to test?

Review the roadmap.md file to ensure all instances of the command have been updated consistently and that the documentation accurately reflects the intended command structure.

### Why make this change?

The `save` command name better represents the action being performed and provides a more intuitive user experience than `record`. This change aligns the command terminology with common CLI conventions.