### PR TITLE
Adds scaffolding for commands

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,0 +1,17 @@
+use clap::{Parser, Subcommand};
+
+#[derive(Parser)]
+#[command(name = "markit")]
+#[command(about = "A CLI snippet runner/bookmarker", long_about = None)]
+pub struct Cli {
+    #[command(subcommand)]
+    pub command: Commands,
+}
+
+#[derive(Subcommand)]
+pub enum Commands {
+    Save { name: String },
+    Run { name: String },
+    List,
+    Show { name: String },
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,22 @@
+mod cli;
+use clap::Parser;
+use cli::{Cli, Commands};
+
 fn main() {
-    println!("Hello, world!");
+    let args = Cli::parse();
+
+    match args.command {
+        Commands::Save { name } => {
+            println!("Would save command '{}'", name);
+        }
+        Commands::Run { name } => {
+            println!("Would run command '{}'", name);
+        }
+        Commands::List => {
+            println!("Would list all bookmarks");
+        }
+        Commands::Show { name } => {
+            println!("Would show snippet '{}'", name);
+        }
+    }
 }


### PR DESCRIPTION
### TL;DR

Added CLI interface for a snippet runner/bookmarker tool using clap.

### What changed?

- Created a new `cli.rs` module that defines the command-line interface structure using clap
- Implemented four commands: `save`, `run`, `list`, and `show`
- Updated `main.rs` to parse CLI arguments and handle each command with placeholder functionality

### How to test?

Run the application with various commands to verify the CLI interface works:

```bash
cargo run -- save my-snippet
cargo run -- run my-snippet
cargo run -- list
cargo run -- show my-snippet
```

Each command should output a message indicating what it would do.

### Why make this change?

This change establishes the foundation for a CLI tool that can save, run, list, and show command snippets. The implementation provides the command structure and argument parsing, setting up the framework for the actual functionality to be added in future changes.