### PR TITLE
Creates and outputs snippet for save command

### DIFF
--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1,0 +1,1 @@
+pub mod save;

--- a/src/commands/save.rs
+++ b/src/commands/save.rs
@@ -1,0 +1,41 @@
+use crate::models::Snippet;
+use std::io::{self, BufRead, Write};
+
+pub fn save_command(name: String) -> () {
+    let description = read_description_input();
+    let content = read_content_input();
+    let entry = Snippet {
+        name,
+        description,
+        content,
+        executable: true,
+    };
+
+    println!("new entry added: {:?}", entry);
+}
+
+fn read_description_input() -> String {
+    print!("📝 Enter description: ");
+    io::stdout().flush().unwrap();
+
+    let mut description = String::new();
+    io::stdin().read_line(&mut description).unwrap();
+    let description = description.trim().to_string();
+    description
+}
+
+fn read_content_input() -> String {
+    println!("💡 type/paste your command below (end with 'EOF' on a new line):");
+    let stdin = io::stdin();
+    let mut content = String::new();
+    for line in stdin.lock().lines() {
+        let line = line.unwrap();
+        if line.trim() == "EOF" {
+            break;
+        }
+
+        content.push_str(&line);
+        content.push('\n');
+    }
+    content
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,13 +1,17 @@
 mod cli;
+mod commands;
+mod models;
+
 use clap::Parser;
 use cli::{Cli, Commands};
+use commands::save;
 
 fn main() {
     let args = Cli::parse();
 
     match args.command {
         Commands::Save { name } => {
-            println!("Would save command '{}'", name);
+            save::save_command(name);
         }
         Commands::Run { name } => {
             println!("Would run command '{}'", name);

--- a/src/models.rs
+++ b/src/models.rs
@@ -1,0 +1,9 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct Snippet {
+    pub name: String,
+    pub description: String,
+    pub content: String,
+    pub executable: bool,
+}


### PR DESCRIPTION
### TL;DR

Implement the `save` command functionality to collect and store command snippets.

### What changed?

- Created a new module structure with `commands/mod.rs` and `commands/save.rs`
- Implemented the `save_command` function that:
  - Prompts users for a description
  - Collects multi-line command content (terminated with 'EOF')
  - Creates a `Snippet` object with the provided information
- Added a new `models.rs` file with a `Snippet` struct that uses Serde for serialization
- Updated `main.rs` to use the new save command implementation instead of just printing a message

### How to test?

1. Run the application with the save command: `cargo run -- save my-command`
2. Enter a description when prompted
3. Type or paste your command content
4. Type `EOF` on a new line to finish input
5. Verify that the application displays the new entry with the provided information

### Why make this change?

This change implements the core functionality for saving command snippets, which is a fundamental feature of the application. It allows users to store commands with descriptive metadata for later use, making it easier to remember and reuse complex commands.