### PR TITLE
Save command saves to file

### DIFF
--- a/src/commands/save.rs
+++ b/src/commands/save.rs
@@ -1,4 +1,4 @@
-use crate::models::Snippet;
+use crate::{models::Snippet, storage};
 use std::io::{self, BufRead, Write};
 
 pub fn save_command(name: String) -> () {
@@ -11,7 +11,7 @@ pub fn save_command(name: String) -> () {
         executable: true,
     };
 
-    println!("new entry added: {:?}", entry);
+    storage::save_to_file(entry);
 }
 
 fn read_description_input() -> String {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,7 @@
 mod cli;
 mod commands;
 mod models;
+mod storage;
 
 use clap::Parser;
 use cli::{Cli, Commands};

--- a/src/models.rs
+++ b/src/models.rs
@@ -7,3 +7,8 @@ pub struct Snippet {
     pub content: String,
     pub executable: bool,
 }
+
+#[derive(Serialize, Deserialize, Default)]
+pub struct SnippetStore {
+    pub snippets: Vec<Snippet>,
+}

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -1,0 +1,29 @@
+use std::{fs::File, path::PathBuf};
+
+use crate::models::{Snippet, SnippetStore};
+
+pub fn save_to_file(new_snippet: Snippet) -> () {
+    let path = get_storage_path();
+
+    let mut store = if path.exists() {
+        let file = File::open(&path).unwrap();
+        serde_yaml::from_reader(file).unwrap_or_default()
+    } else {
+        SnippetStore::default()
+    };
+
+    store.snippets.push(new_snippet);
+
+    let file = File::create(&path).unwrap();
+    serde_yaml::to_writer(file, &store).unwrap();
+
+    println!("✅ Snippet saved.");
+}
+
+fn get_storage_path() -> PathBuf {
+    let dir = dirs::home_dir()
+        .unwrap_or_else(|| PathBuf::from("."))
+        .join(".markit");
+    std::fs::create_dir_all(&dir).unwrap();
+    dir.join("bookmarks.yml")
+}


### PR DESCRIPTION
### TL;DR

Implement persistent storage for snippets using YAML files.

### What changed?

- Added a new `storage` module with functionality to save snippets to a file
- Created a `SnippetStore` struct to hold collections of snippets
- Updated the `save_command` to use the new storage functionality instead of just printing the entry
- Added file system operations to store snippets in `~/.markit/bookmarks.yml`

### How to test?

1. Run the application and save a snippet using the save command
2. Verify that a `.markit` directory is created in your home directory
3. Check that `~/.markit/bookmarks.yml` contains your saved snippet
4. Save multiple snippets and confirm they're all stored in the file

### Why make this change?

Previously, snippets were only displayed in the console and not persisted between application runs. This change implements proper storage functionality so that saved snippets are preserved and can be retrieved later, which is essential for the application's core functionality.