### PR TITLE
Adds list command output

### DIFF
--- a/src/commands/list.rs
+++ b/src/commands/list.rs
@@ -1,0 +1,16 @@
+use crate::storage;
+
+pub fn list_command() -> () {
+    match storage::get_snippets() {
+        Some(store) => {
+            println!("📚 Saved Snippets:\n");
+
+            for snippet in store.snippets {
+                println!("🔹 {}\n   {}", snippet.name, snippet.description);
+            }
+        }
+        None => {
+            println!("📭 No snippets saved yet.");
+        }
+    }
+}

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1,1 +1,2 @@
+pub mod list;
 pub mod save;

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,6 +7,8 @@ use clap::Parser;
 use cli::{Cli, Commands};
 use commands::save;
 
+use crate::commands::list;
+
 fn main() {
     let args = Cli::parse();
 
@@ -18,7 +20,7 @@ fn main() {
             println!("Would run command '{}'", name);
         }
         Commands::List => {
-            println!("Would list all bookmarks");
+            list::list_command();
         }
         Commands::Show { name } => {
             println!("Would show snippet '{}'", name);

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -20,6 +20,23 @@ pub fn save_to_file(new_snippet: Snippet) -> () {
     println!("✅ Snippet saved.");
 }
 
+pub fn get_snippets() -> Option<SnippetStore> {
+    let path = get_storage_path();
+
+    if !path.exists() {
+        return None;
+    }
+
+    let file = File::open(&path).unwrap();
+    let store: SnippetStore = serde_yaml::from_reader(file).unwrap_or_default();
+
+    if store.snippets.is_empty() {
+        return None;
+    }
+
+    Some(store)
+}
+
 fn get_storage_path() -> PathBuf {
     let dir = dirs::home_dir()
         .unwrap_or_else(|| PathBuf::from("."))


### PR DESCRIPTION
### TL;DR

Implemented the `list` command to display all saved snippets.

### What changed?

- Added a new `list.rs` module with a `list_command()` function that displays all saved snippets
- Created a `get_snippets()` function in the storage module to retrieve saved snippets
- Connected the `list` command in the CLI to the new implementation
- Added emoji formatting to make the output more visually appealing

### How to test?

1. Save a few snippets using the save command
2. Run `cargo run -- list` to see all saved snippets
3. Verify that each snippet shows its name and description
4. Test the empty state by clearing the storage file and running the list command again

### Why make this change?

This implements a core feature of the snippet manager - the ability to view all saved snippets. Without this functionality, users would have no way to see what snippets they've previously saved. The implementation provides a clean, formatted output that makes it easy to browse through saved snippets.