### PR TITLE
Adds show command

### DIFF
--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1,2 +1,3 @@
 pub mod list;
 pub mod save;
+pub mod show;

--- a/src/commands/show.rs
+++ b/src/commands/show.rs
@@ -1,0 +1,14 @@
+use crate::storage;
+
+pub fn show_command(name: String) -> () {
+    match storage::get_snippet_by_name(&name) {
+        Some(snippet) => {
+            println!("🔎 Snippet: {}", snippet.name);
+            println!("📄 Description: {}", snippet.description);
+            println!("📋 Content:\n{}", snippet.content);
+        }
+        None => {
+            println!("⛔ Snippet '{}' not found.", name);
+        }
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,7 +7,7 @@ use clap::Parser;
 use cli::{Cli, Commands};
 use commands::save;
 
-use crate::commands::list;
+use crate::commands::{list, show};
 
 fn main() {
     let args = Cli::parse();
@@ -23,7 +23,7 @@ fn main() {
             list::list_command();
         }
         Commands::Show { name } => {
-            println!("Would show snippet '{}'", name);
+            show::show_command(name);
         }
     }
 }

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -37,6 +37,11 @@ pub fn get_snippets() -> Option<SnippetStore> {
     Some(store)
 }
 
+pub fn get_snippet_by_name(name: &str) -> Option<Snippet> {
+    let store = get_snippets()?;
+    store.snippets.into_iter().find(|s| s.name == name)
+}
+
 fn get_storage_path() -> PathBuf {
     let dir = dirs::home_dir()
         .unwrap_or_else(|| PathBuf::from("."))


### PR DESCRIPTION
### TL;DR

Implemented the `show` command to display snippet details.

### What changed?

- Added a new `show.rs` module with the `show_command` function that displays a snippet's name, description, and content
- Exposed the new module through `commands/mod.rs`
- Implemented the `show` command in `main.rs` by replacing the placeholder with the actual functionality
- Added a `get_snippet_by_name` helper function in `storage.rs` to retrieve a specific snippet

### How to test?

1. Save a snippet: `cargo run -- save my-snippet`
2. Show the snippet: `cargo run -- show my-snippet`
3. Verify that the name, description, and content are displayed correctly
4. Try showing a non-existent snippet to verify the error message

### Why make this change?

This completes the core functionality of the snippet manager by allowing users to view the full details of a specific snippet. The show command is essential for retrieving and displaying saved snippets, complementing the existing save and list commands.