### PR TITLE
Adds fuzzy search for show command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -117,6 +117,7 @@ dependencies = [
  "clap",
  "comfy-table",
  "dirs",
+ "nucleo-matcher",
  "serde",
  "serde_yaml",
 ]
@@ -272,6 +273,22 @@ checksum = "96936507f153605bddfcda068dd804796c84324ed2510809e5b2a624c81da765"
 dependencies = [
  "autocfg",
  "scopeguard",
+]
+
+[[package]]
+name = "memchr"
+version = "2.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
+
+[[package]]
+name = "nucleo-matcher"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf33f538733d1a5a3494b836ba913207f14d9d4a1d3cd67030c5061bdd2cac85"
+dependencies = [
+ "memchr",
+ "unicode-segmentation",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,3 +9,4 @@ serde = { version = "1", features = ["derive"] }
 serde_yaml = "0.9"
 dirs = "5"
 comfy-table = "=7.1.4"
+nucleo-matcher = "0.3.1"

--- a/src/models.rs
+++ b/src/models.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct Snippet {
     pub name: String,
     pub description: String,


### PR DESCRIPTION
### TL;DR

Added fuzzy matching for snippet search using the nucleo-matcher library.

### What changed?

- Added the `nucleo-matcher` dependency to Cargo.toml and Cargo.lock
- Modified the `get_snippet_by_name` function to use fuzzy matching instead of exact name matching
- Made the `Snippet` struct cloneable by deriving the `Clone` trait

### How to test?

1. Try searching for snippets using partial or misspelled names
2. Verify that the system returns the closest matching snippet based on the fuzzy search
3. For example, if you have a snippet named "example-code", try searching with "exampl" or "exmple" and confirm it returns the correct snippet

### Why make this change?

This improves the user experience by allowing for more flexible snippet searches. Users no longer need to remember the exact name of a snippet - the system will find the closest match based on the provided query, making the tool more forgiving and intuitive to use.