### PR TITLE
Adds run command

### DIFF
--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1,3 +1,4 @@
 pub mod list;
+pub mod run;
 pub mod save;
 pub mod show;

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -1,0 +1,32 @@
+use crate::{storage, ui};
+use std::process::Command;
+
+pub fn run_command(name: String) -> () {
+    let snippets = match storage::get_snippets_by_name(&name) {
+        Some(s) => s,
+        None => {
+            println!("⛔ Snippet '{}' not found.", name);
+            return;
+        }
+    };
+
+    let snippet = match ui::select_snippet(snippets) {
+        Some(s) => s,
+        None => {
+            println!("⛔ Snippet '{}' not found.", name);
+            return;
+        }
+    };
+
+    println!("🚀 Running: {}", snippet.name);
+    println!("📋 {}", snippet.content);
+
+    let shell = std::env::var("SHELL").unwrap_or_else(|_| "/bin/sh".into());
+    let status = Command::new(shell).arg("-c").arg(&snippet.content).status();
+
+    match status {
+        Ok(code) if code.success() => println!("✅ Command ran successfully."),
+        Ok(code) => println!("⚠️ Command exited with status: {}", code),
+        Err(err) => println!("⛔ Failed to run command: {}", err),
+    }
+}

--- a/src/commands/show.rs
+++ b/src/commands/show.rs
@@ -1,5 +1,4 @@
-use crate::{models::Snippet, storage};
-use dialoguer::{Select, theme::ColorfulTheme};
+use crate::{storage, ui};
 
 pub fn show_command(name: String) {
     let snippets = match storage::get_snippets_by_name(&name) {
@@ -10,7 +9,7 @@ pub fn show_command(name: String) {
         }
     };
 
-    let snippet = match select_snippet(snippets) {
+    let snippet = match ui::select_snippet(snippets) {
         Some(s) => s,
         None => {
             println!("⛔ Snippet '{}' not found.", name);
@@ -21,17 +20,4 @@ pub fn show_command(name: String) {
     println!("🔎 Snippet: {}", snippet.name);
     println!("📄 Description: {}", snippet.description);
     println!("📋 Content:\n{}", snippet.content);
-}
-
-fn select_snippet(matches: Vec<Snippet>) -> Option<Snippet> {
-    let options: Vec<&str> = matches.iter().map(|s| s.name.as_str()).collect();
-
-    let selection = Select::with_theme(&ColorfulTheme::default())
-        .with_prompt("Multiple matches found. Select one:")
-        .items(&options)
-        .default(0)
-        .interact()
-        .ok()?;
-
-    matches.get(selection).cloned()
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,12 +2,12 @@ mod cli;
 mod commands;
 mod models;
 mod storage;
+mod ui;
 
 use clap::Parser;
 use cli::{Cli, Commands};
-use commands::save;
 
-use crate::commands::{list, show};
+use crate::commands::{list, run, save, show};
 
 fn main() {
     let args = Cli::parse();
@@ -17,7 +17,7 @@ fn main() {
             save::save_command(name);
         }
         Commands::Run { name } => {
-            println!("Would run command '{}'", name);
+            run::run_command(name);
         }
         Commands::List => {
             list::list_command();

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -1,0 +1,16 @@
+use dialoguer::{Select, theme::ColorfulTheme};
+
+use crate::models::Snippet;
+
+pub fn select_snippet(matches: Vec<Snippet>) -> Option<Snippet> {
+    let options: Vec<&str> = matches.iter().map(|s| s.name.as_str()).collect();
+
+    let selection = Select::with_theme(&ColorfulTheme::default())
+        .with_prompt("Multiple matches found. Select one:")
+        .items(&options)
+        .default(0)
+        .interact()
+        .ok()?;
+
+    matches.get(selection).cloned()
+}


### PR DESCRIPTION
### TL;DR

Implement the `run` command to execute saved snippets in the user's shell.

### What changed?

- Added a new `run.rs` module that implements the functionality to execute saved snippets
- Created a new `ui` module that extracts the snippet selection logic from `show.rs` for reuse
- Connected the `run` command in the CLI to the new implementation
- The run command finds a snippet by name, lets the user select one if multiple matches exist, and executes it using the user's shell

### How to test?

1. Save a snippet using `save` command
2. Run the snippet using `run <snippet-name>`
3. Verify that the snippet executes in your shell
4. Test with both successful and failing commands to see different status messages
5. Test with snippets that have multiple matches to verify the selection UI works

### Why make this change?

This completes the core functionality of the snippet manager by allowing users to not only save and view snippets but also execute them directly. The implementation respects the user's shell environment and provides clear feedback about execution status, making it a practical tool for running frequently used commands.