### PR TITLE
Adds multiple ways to exit save editor

### DIFF
--- a/src/commands/save.rs
+++ b/src/commands/save.rs
@@ -25,17 +25,27 @@ fn read_description_input() -> String {
 }
 
 fn read_content_input() -> String {
-    println!("💡 type/paste your command below (end with 'EOF' on a new line):");
-    let stdin = io::stdin();
-    let mut content = String::new();
-    for line in stdin.lock().lines() {
-        let line = line.unwrap();
-        if line.trim() == "EOF" {
-            break;
-        }
+    println!("💡 Paste your command below.");
+    println!("👉 End with either:");
+    println!("   - Ctrl+D (Unix/macOS) or Ctrl+Z then Enter (Windows)");
+    println!("   - Or type 'EOF' or '---' on a new line to finish:");
 
-        content.push_str(&line);
-        content.push('\n');
+    let mut content = String::new();
+
+    let stdin = io::stdin();
+    for line in stdin.lock().lines() {
+        match line {
+            Ok(l) if l.trim() == "EOF" || l.trim() == "---" => break,
+            Ok(l) => {
+                content.push_str(&l);
+                content.push('\n');
+            }
+            Err(err) => {
+                eprintln!("⛔ Error reading input: {}", err);
+                break;
+            }
+        }
     }
+
     content
 }


### PR DESCRIPTION
### TL;DR

Improved the command input experience with clearer instructions and more flexible input termination options.

### What changed?

- Enhanced the `read_content_input()` function with clearer instructions for users
- Added multiple ways to terminate input:
  - Ctrl+D (Unix/macOS) or Ctrl+Z then Enter (Windows)
  - Typing 'EOF' or '---' on a new line
- Improved error handling for input reading failures
- Restructured the input processing logic for better readability

### How to test?

1. Run the save command
2. Test all input termination methods:
   - Try ending input with 'EOF'
   - Try ending input with '---'
   - Try using Ctrl+D or Ctrl+Z depending on your OS
3. Verify the command content is correctly saved

### Why make this change?

This change makes the tool more user-friendly by providing clearer instructions and offering multiple ways to terminate input. The improved error handling also makes the application more robust when dealing with unexpected input scenarios.