### PR TITLE
Makes show return single result if there is one

### DIFF
--- a/src/ui.rs
+++ b/src/ui.rs
@@ -3,6 +3,10 @@ use dialoguer::{Select, theme::ColorfulTheme};
 use crate::models::Snippet;
 
 pub fn select_snippet(matches: Vec<Snippet>) -> Option<Snippet> {
+    if matches.len() == 1 {
+        return matches.get(0).cloned();
+    }
+
     let options: Vec<&str> = matches.iter().map(|s| s.name.as_str()).collect();
 
     let selection = Select::with_theme(&ColorfulTheme::default())


### PR DESCRIPTION
### TL;DR

Automatically select a snippet when there's only one match

### What changed?

Added a condition to the `select_snippet` function that automatically returns the single match when only one snippet is found, bypassing the selection UI.

### How to test?

1. Run a search that returns exactly one snippet match
2. Verify that the snippet is automatically selected without showing the selection UI
3. Run a search with multiple matches to confirm the selection UI still appears

### Why make this change?

This improves the user experience by eliminating an unnecessary selection step when there's only one possible choice. Users can get to their desired snippet faster when there's no ambiguity in the search results.