### PR TITLE
Adds logic for executable flag

### DIFF
--- a/src/commands/list.rs
+++ b/src/commands/list.rs
@@ -26,12 +26,14 @@ fn build_output_table(store: SnippetStore) -> Table {
     table.set_header(vec![
         Cell::new("Name").fg(header_color),
         Cell::new("Description").fg(header_color),
+        Cell::new("Executable").fg(header_color),
     ]);
 
     for snippet in store.snippets {
         table.add_row(Row::from(vec![
             Cell::new(snippet.name).fg(Color::White),
             Cell::new(snippet.description).fg(Color::White),
+            Cell::new(if snippet.executable { "yes" } else { "no" }).fg(Color::White),
         ]));
     }
 

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -18,6 +18,11 @@ pub fn run_command(name: String) -> () {
         }
     };
 
+    if !snippet.executable {
+        println!("⛔ Snippet '{}' not executable.", snippet.name);
+        return;
+    }
+
     println!("🚀 Running: {}", snippet.name);
     println!("📋 {}", snippet.content);
 

--- a/src/commands/save.rs
+++ b/src/commands/save.rs
@@ -3,12 +3,13 @@ use std::io::{self, BufRead, Write};
 
 pub fn save_command(name: String) -> () {
     let description = read_description_input();
+    let executable = read_executable_input();
     let content = read_content_input();
     let entry = Snippet {
         name,
         description,
         content,
-        executable: true,
+        executable,
     };
 
     storage::save_to_file(entry);
@@ -22,6 +23,17 @@ fn read_description_input() -> String {
     io::stdin().read_line(&mut description).unwrap();
     let description = description.trim().to_string();
     description
+}
+
+fn read_executable_input() -> bool {
+    print!("🚀 Executable? (y/N): ");
+    io::stdout().flush().unwrap();
+
+    let mut input = String::new();
+    io::stdin().read_line(&mut input).unwrap();
+    let trimmed = input.trim().to_lowercase();
+
+    matches!(trimmed.as_str(), "y" | "yes")
 }
 
 fn read_content_input() -> String {

--- a/src/commands/show.rs
+++ b/src/commands/show.rs
@@ -20,4 +20,5 @@ pub fn show_command(name: String) {
     println!("🔎 Snippet: {}", snippet.name);
     println!("📄 Description: {}", snippet.description);
     println!("📋 Content:\n{}", snippet.content);
+    println!("🚀 Executable: {}", snippet.executable);
 }


### PR DESCRIPTION
### TL;DR

Added executable flag support to snippets with UI integration across commands.

### What changed?

- Added an "Executable" column to the list command output table
- Updated the run command to check if a snippet is executable before running it
- Modified the save command to prompt users whether a snippet should be executable
- Enhanced the show command to display the executable status of a snippet

### How to test?

1. Create a new snippet with `save` command and test both "yes" and "no" responses to the executable prompt
2. Run `list` command to verify the executable status appears in the table
3. Try `run` command on both executable and non-executable snippets to confirm proper behavior
4. Use `show` command to verify the executable status is displayed correctly

### Why make this change?

This change improves safety by allowing users to mark snippets as non-executable, preventing accidental execution of snippets that are meant for reference only. It also enhances the user experience by clearly indicating which snippets can be run.