### PR TITLE
Adds helper function for snippet retrieval

### DIFF
--- a/src/commands/copy.rs
+++ b/src/commands/copy.rs
@@ -1,23 +1,9 @@
 use arboard::Clipboard;
 
-use crate::{storage, ui};
+use crate::commands::helper::get_snippet;
 
 pub fn copy_command(name: String) -> () {
-    let snippets = match storage::get_snippets_by_name(&name) {
-        Some(s) => s,
-        None => {
-            println!("⛔ Snippet '{}' not found.", name);
-            return;
-        }
-    };
-
-    let snippet = match ui::select_snippet(snippets) {
-        Some(s) => s,
-        None => {
-            println!("⛔ Snippet '{}' not found.", name);
-            return;
-        }
-    };
+    let snippet = get_snippet(name).unwrap();
 
     let mut clipboard = Clipboard::new().expect("Failed to access clipboard");
     clipboard

--- a/src/commands/helper.rs
+++ b/src/commands/helper.rs
@@ -1,0 +1,19 @@
+use crate::{models::Snippet, storage, ui};
+
+pub fn get_snippet(name: String) -> Option<Snippet> {
+    let snippets = match storage::get_snippets_by_name(&name) {
+        Some(s) => s,
+        None => {
+            println!("⛔ Snippet '{}' not found.", name);
+            return None;
+        }
+    };
+
+    return match ui::select_snippet(snippets) {
+        Some(s) => Some(s),
+        None => {
+            println!("⛔ Snippet '{}' not found.", name);
+            return None;
+        }
+    };
+}

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1,4 +1,5 @@
 pub mod copy;
+pub mod helper;
 pub mod list;
 pub mod run;
 pub mod save;

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -1,22 +1,8 @@
-use crate::{storage, ui};
+use crate::commands::helper::get_snippet;
 use std::process::Command;
 
 pub fn run_command(name: String) -> () {
-    let snippets = match storage::get_snippets_by_name(&name) {
-        Some(s) => s,
-        None => {
-            println!("⛔ Snippet '{}' not found.", name);
-            return;
-        }
-    };
-
-    let snippet = match ui::select_snippet(snippets) {
-        Some(s) => s,
-        None => {
-            println!("⛔ Snippet '{}' not found.", name);
-            return;
-        }
-    };
+    let snippet = get_snippet(name).unwrap();
 
     if !snippet.executable {
         println!("⛔ Snippet '{}' not executable.", snippet.name);

--- a/src/commands/show.rs
+++ b/src/commands/show.rs
@@ -1,21 +1,7 @@
-use crate::{storage, ui};
+use crate::commands::helper::get_snippet;
 
 pub fn show_command(name: String) {
-    let snippets = match storage::get_snippets_by_name(&name) {
-        Some(s) => s,
-        None => {
-            println!("⛔ Snippet '{}' not found.", name);
-            return;
-        }
-    };
-
-    let snippet = match ui::select_snippet(snippets) {
-        Some(s) => s,
-        None => {
-            println!("⛔ Snippet '{}' not found.", name);
-            return;
-        }
-    };
+    let snippet = get_snippet(name).unwrap();
 
     println!("🔎 Snippet: {}", snippet.name);
     println!("📄 Description: {}", snippet.description);


### PR DESCRIPTION
### TL;DR

Refactored snippet retrieval logic into a shared helper function to reduce code duplication.

### What changed?

- Created a new `helper.rs` module with a `get_snippet()` function that centralizes the logic for retrieving snippets by name
- Updated the `copy`, `run`, and `show` commands to use this helper function instead of duplicating the retrieval logic
- Added the new helper module to the module exports

### How to test?

- Test the `copy`, `run`, and `show` commands with existing snippets to verify they still work correctly
- Test with non-existent snippet names to ensure error handling works properly
- Verify that the behaviour remains unchanged from the user's perspective

### Why make this change?

The previous implementation had duplicate code for retrieving and selecting snippets across multiple command modules. This refactoring improves code maintainability by centralizing this common functionality, making the codebase more DRY (Don't Repeat Yourself) and easier to maintain.