### PR TITLE
Adds delete command

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -15,4 +15,5 @@ pub enum Commands {
     List,
     Show { name: String },
     Copy { name: String },
+    Delete { name: String },
 }

--- a/src/commands/delete.rs
+++ b/src/commands/delete.rs
@@ -1,0 +1,26 @@
+use crate::{commands::helper::get_snippet, storage};
+
+pub fn delete_command(name: String) -> () {
+    let mut store = match storage::get_snippets() {
+        Some(s) => s,
+        None => {
+            println!("📭 No snippets to delete.");
+            return;
+        }
+    };
+
+    let delete_snippet = match get_snippet(name) {
+        Some(s) => s,
+        None => {
+            return;
+        }
+    };
+
+    store.snippets.retain(|s| s.name != delete_snippet.name);
+
+    if let Err(err) = storage::write_snippets(&store) {
+        eprintln!("⛔ Failed to update snippets file: {}", err);
+    } else {
+        println!("🗑️ Snippet '{}' deleted.", delete_snippet.name);
+    }
+}

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1,4 +1,5 @@
 pub mod copy;
+pub mod delete;
 pub mod helper;
 pub mod list;
 pub mod run;

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,7 +7,7 @@ mod ui;
 use clap::Parser;
 use cli::{Cli, Commands};
 
-use crate::commands::{copy, list, run, save, show};
+use crate::commands::{copy, delete, list, run, save, show};
 
 fn main() {
     let args = Cli::parse();
@@ -27,6 +27,9 @@ fn main() {
         }
         Commands::Copy { name } => {
             copy::copy_command(name);
+        }
+        Commands::Delete { name } => {
+            delete::delete_command(name);
         }
     }
 }

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -63,6 +63,13 @@ pub fn get_snippets_by_name(query: &str) -> Option<Vec<Snippet>> {
         .collect()
 }
 
+pub fn write_snippets(store: &SnippetStore) -> Result<(), Box<dyn std::error::Error>> {
+    let path = get_storage_path();
+    let file = File::create(&path)?;
+    serde_yaml::to_writer(file, store)?;
+    Ok(())
+}
+
 fn get_storage_path() -> PathBuf {
     let dir = dirs::home_dir()
         .unwrap_or_else(|| PathBuf::from("."))


### PR DESCRIPTION
### TL;DR

Added a new `Delete` command to remove snippets from the CLI tool.

### What changed?

- Added a new `Delete` command to the CLI enum in `cli.rs`
- Created a new module `commands/delete.rs` with the implementation for deleting snippets
- Added the delete module to the module exports in `commands/mod.rs`
- Updated the main command handler in `main.rs` to handle the new Delete command
- Added a new `write_snippets` function in `storage.rs` to persist changes after deletion

### How to test?

1. Run the CLI with the delete command: `cargo run -- delete "snippet_name"`
2. Verify that the specified snippet is removed from storage
3. Try to delete a non-existent snippet to ensure proper error handling
4. Run the list command to confirm the snippet is no longer available

### Why make this change?

This change completes the basic CRUD operations for the snippet management tool. Users can now delete snippets they no longer need, which improves the overall usability of the tool and prevents the accumulation of outdated or unused snippets.