### PR TITLE
Adds logic to prevent naming collisions

### DIFF
--- a/src/commands/edit.rs
+++ b/src/commands/edit.rs
@@ -47,6 +47,18 @@ pub fn edit_command(name: String) -> () {
         }
     };
 
+    if store
+        .snippets
+        .iter()
+        .any(|s| s.name.eq_ignore_ascii_case(&edited.name) && s.name != original.name)
+    {
+        eprintln!(
+            "⛔ Another snippet with the name '{}' already exists.",
+            edited.name
+        );
+        return;
+    }
+
     store.snippets.retain(|s| s.name != original.name);
     store.snippets.push(edited.clone());
 

--- a/src/commands/save.rs
+++ b/src/commands/save.rs
@@ -2,6 +2,17 @@ use crate::{models::Snippet, storage};
 use std::io::{self, BufRead, Write};
 
 pub fn save_command(name: String) -> () {
+    if let Some(store) = storage::get_snippets() {
+        if store
+            .snippets
+            .iter()
+            .any(|s| s.name.eq_ignore_ascii_case(&name))
+        {
+            eprintln!("⛔ A snippet with the name '{}' already exists.", name);
+            return;
+        }
+    }
+
     let description = read_description_input();
     let executable = read_executable_input();
     let content = read_content_input();


### PR DESCRIPTION
### TL;DR

Added validation to prevent duplicate snippet names when saving or editing snippets.

### What changed?

- Added a check in the `save_command` function to verify if a snippet with the same name already exists before saving
- Added a similar check in the `edit_command` function to prevent renaming a snippet to a name that already exists
- Both checks use case-insensitive comparison (`eq_ignore_ascii_case`) to ensure uniqueness regardless of capitalization
- Added appropriate error messages to inform users when they attempt to create duplicate snippets

### How to test?

1. Try to save a new snippet with a name that already exists
   - You should see an error message: "⛔ A snippet with the name 'X' already exists."
   - The save operation should be aborted

2. Try to edit an existing snippet and change its name to one that already exists
   - You should see an error message: "⛔ Another snippet with the name 'X' already exists."
   - The edit operation should be aborted

3. Verify that you can still save snippets with unique names and edit snippets without name conflicts

### Why make this change?

This change prevents accidental overwriting of existing snippets and improves the user experience by providing clear feedback when attempting to create duplicate entries. It maintains data integrity by ensuring snippet names remain unique within the storage system.