### PR TITLE
Adds metadata for created and updated dates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "android-tzdata"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
+
+[[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "anstream"
 version = "0.6.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -97,6 +112,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967"
 
 [[package]]
+name = "bumpalo"
+version = "3.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "793db76d6187cd04dff33004d8e6c9cc4e05cd330500379d2394209271b4aeee"
+
+[[package]]
 name = "bytemuck"
 version = "1.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -109,10 +130,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
 
 [[package]]
+name = "cc"
+version = "1.2.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d487aa071b5f64da6f19a3e848e3578944b726ee5a4854b82172f02aa876bfdc"
+dependencies = [
+ "shlex",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9555578bc9e57714c812a1f84e4fc5b4d21fcb063490c624de019f7464c91268"
+
+[[package]]
+name = "chrono"
+version = "0.4.41"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c469d952047f47f91b68d1cba3f10d63c11d73e4636f24f08daf0278abf01c4d"
+dependencies = [
+ "android-tzdata",
+ "iana-time-zone",
+ "js-sys",
+ "num-traits",
+ "serde",
+ "wasm-bindgen",
+ "windows-link",
+]
 
 [[package]]
 name = "clap"
@@ -159,6 +204,7 @@ name = "cli-snippet-manager"
 version = "0.1.0"
 dependencies = [
  "arboard",
+ "chrono",
  "clap",
  "comfy-table",
  "dialoguer",
@@ -207,6 +253,12 @@ dependencies = [
  "unicode-width",
  "windows-sys 0.59.0",
 ]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "crc32fast"
@@ -382,6 +434,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "iana-time-zone"
+version = "0.1.63"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0c919e5debc312ad217002b8048a17b7d83f80703865bbfcfebb0458b0b27d8"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "image"
 version = "0.25.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -421,6 +497,16 @@ name = "jpeg-decoder"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f5d4a7da358eff58addd2877a45865158f0d78c911d43a5784ceb7bbf52833b0"
+
+[[package]]
+name = "js-sys"
+version = "0.3.77"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f"
+dependencies = [
+ "once_cell",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "libc"
@@ -705,6 +791,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustversion"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a0d197bd2c9dc6e53b84da9556a69ba4cdfab8619eb41a8bd1cc2027a0f6b1d"
+
+[[package]]
 name = "ryu"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -754,6 +846,12 @@ name = "shell-words"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24188a676b6ae68c3b2cb3a01be17fbf7240ce009799bb56d5b1409051e78fde"
+
+[[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "simd-adler32"
@@ -874,6 +972,64 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-bindgen"
+version = "0.2.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1edc8929d7499fc4e8f0be2262a241556cfc54a0bea223790e71446f2aab1ef5"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+]
+
+[[package]]
+name = "wasm-bindgen-backend"
+version = "0.2.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f0a0651a5c2bc21487bde11ee802ccaf4c51935d0d3d42a6101f98161700bc6"
+dependencies = [
+ "bumpalo",
+ "log",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fe63fc6d09ed3792bd0897b314f53de8e16568c2b3f7982f468c0bf9bd0b407"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-backend",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
 name = "weezl"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -900,6 +1056,65 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows-core"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a47fddd13af08290e67f4acabf4b459f647552718f683a7b415d290ac744a836"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd9211b69f8dcdfa817bfd14bf1c97c9188afa36f4750130fcdf3f400eca9fa8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-link"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
+
+[[package]]
+name = "windows-result"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
+dependencies = [
+ "windows-link",
+]
 
 [[package]]
 name = "windows-sys"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,3 +13,4 @@ nucleo-matcher = "0.3.1"
 dialoguer = "0.11"
 arboard = "3.3"
 tempfile = "3.20.0"
+chrono = { version = "0.4", features = ["serde"] }

--- a/src/commands/helper.rs
+++ b/src/commands/helper.rs
@@ -1,4 +1,7 @@
-use crate::{models::Snippet, storage, ui};
+use crate::{
+    models::{PartialSnippet, Snippet},
+    storage, ui,
+};
 
 pub fn get_snippet(name: String) -> Option<Snippet> {
     let snippets = match storage::get_snippets_by_name(&name) {
@@ -16,4 +19,13 @@ pub fn get_snippet(name: String) -> Option<Snippet> {
             return None;
         }
     };
+}
+
+pub fn redact_snippet(snippet: &Snippet) -> PartialSnippet {
+    PartialSnippet {
+        name: snippet.name.clone(),
+        description: snippet.description.clone(),
+        content: snippet.content.clone(),
+        executable: snippet.executable,
+    }
 }

--- a/src/commands/list.rs
+++ b/src/commands/list.rs
@@ -27,6 +27,8 @@ fn build_output_table(store: SnippetStore) -> Table {
         Cell::new("Name").fg(header_color),
         Cell::new("Description").fg(header_color),
         Cell::new("Executable").fg(header_color),
+        Cell::new("Created at").fg(header_color),
+        Cell::new("Updated at").fg(header_color),
     ]);
 
     for snippet in store.snippets {
@@ -34,6 +36,8 @@ fn build_output_table(store: SnippetStore) -> Table {
             Cell::new(snippet.name).fg(Color::White),
             Cell::new(snippet.description).fg(Color::White),
             Cell::new(if snippet.executable { "yes" } else { "no" }).fg(Color::White),
+            Cell::new(snippet.created_at).fg(Color::White),
+            Cell::new(snippet.updated_at).fg(Color::White),
         ]));
     }
 

--- a/src/commands/save.rs
+++ b/src/commands/save.rs
@@ -1,3 +1,5 @@
+use chrono::Utc;
+
 use crate::{models::Snippet, storage};
 use std::io::{self, BufRead, Write};
 
@@ -16,11 +18,14 @@ pub fn save_command(name: String) -> () {
     let description = read_description_input();
     let executable = read_executable_input();
     let content = read_content_input();
+    let now = Utc::now();
     let entry = Snippet {
         name,
         description,
         content,
         executable,
+        created_at: now,
+        updated_at: now,
     };
 
     storage::save_to_file(entry);

--- a/src/commands/show.rs
+++ b/src/commands/show.rs
@@ -5,6 +5,8 @@ pub fn show_command(name: String) {
 
     println!("🔎 Snippet: {}", snippet.name);
     println!("📄 Description: {}", snippet.description);
-    println!("📋 Content:\n{}", snippet.content);
     println!("🚀 Executable: {}", snippet.executable);
+    println!("🕒 Created at: {}", snippet.created_at);
+    println!("🕒 Updated at: {}", snippet.updated_at);
+    println!("📋 Content:\n{}", snippet.content);
 }

--- a/src/models.rs
+++ b/src/models.rs
@@ -1,3 +1,4 @@
+use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
@@ -6,9 +7,25 @@ pub struct Snippet {
     pub description: String,
     pub content: String,
     pub executable: bool,
+    #[serde(default = "default_now")]
+    pub created_at: DateTime<Utc>,
+    #[serde(default = "default_now")]
+    pub updated_at: DateTime<Utc>,
+}
+
+fn default_now() -> DateTime<Utc> {
+    Utc::now()
 }
 
 #[derive(Serialize, Deserialize, Default)]
 pub struct SnippetStore {
     pub snippets: Vec<Snippet>,
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct PartialSnippet {
+    pub name: String,
+    pub description: String,
+    pub content: String,
+    pub executable: bool,
 }


### PR DESCRIPTION
### TL;DR

Added timestamp tracking to snippets with the chrono crate.

### What changed?

- Added the chrono crate as a dependency with serde feature enabled
- Added `created_at` and `updated_at` DateTime fields to the Snippet model
- Created a new `PartialSnippet` model for editing that excludes timestamp fields
- Modified the edit command to update the `updated_at` timestamp when a snippet is edited
- Updated the list and show commands to display timestamp information
- Added helper function to convert a Snippet to a PartialSnippet for editing

### How to test?

1. Create a new snippet with `cargo run -- save <name>`
2. View the snippet with `cargo run -- show <name>` to see the timestamps
3. List all snippets with `cargo run -- list` to verify timestamps appear in the table
4. Edit a snippet with `cargo run -- edit <name>` and verify the `updated_at` timestamp changes

### Why make this change?

Adding timestamps provides valuable metadata about when snippets were created and last modified. This helps users track the age and recency of their snippets, making it easier to identify outdated content that might need updating.