### PR TITLE
Adds confirmation for deletion and a force flag

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -10,11 +10,25 @@ pub struct Cli {
 
 #[derive(Subcommand)]
 pub enum Commands {
-    Save { name: String },
-    Run { name: String },
+    Save {
+        name: String,
+    },
+    Run {
+        name: String,
+    },
     List,
-    Show { name: String },
-    Copy { name: String },
-    Delete { name: String },
-    Edit { name: String },
+    Show {
+        name: String,
+    },
+    Copy {
+        name: String,
+    },
+    Delete {
+        name: String,
+        #[arg(short, long)]
+        force: bool,
+    },
+    Edit {
+        name: String,
+    },
 }

--- a/src/commands/delete.rs
+++ b/src/commands/delete.rs
@@ -1,6 +1,8 @@
+use dialoguer::Confirm;
+
 use crate::{commands::helper::get_snippet, storage};
 
-pub fn delete_command(name: String) -> () {
+pub fn delete_command(name: String, force: bool) -> () {
     let mut store = match storage::get_snippets() {
         Some(s) => s,
         None => {
@@ -15,6 +17,22 @@ pub fn delete_command(name: String) -> () {
             return;
         }
     };
+
+    if !force {
+        let prompt = format!(
+            "❗ Are you sure you want to delete '{}'? This cannot be undone.",
+            delete_snippet.name
+        );
+        if !Confirm::new()
+            .with_prompt(prompt)
+            .default(false)
+            .interact()
+            .unwrap_or(false)
+        {
+            println!("🚫 Deletion cancelled.");
+            return;
+        }
+    }
 
     store.snippets.retain(|s| s.name != delete_snippet.name);
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -28,8 +28,8 @@ fn main() {
         Commands::Copy { name } => {
             copy::copy_command(name);
         }
-        Commands::Delete { name } => {
-            delete::delete_command(name);
+        Commands::Delete { name, force } => {
+            delete::delete_command(name, force);
         }
         Commands::Edit { name } => {
             edit::edit_command(name);


### PR DESCRIPTION
### TL;DR

Added a confirmation prompt when deleting snippets with an option to bypass it.

### What changed?

- Added a `--force` flag (with `-f` shorthand) to the `Delete` command in the CLI
- Implemented a confirmation prompt in the delete command that asks users to confirm deletion
- The confirmation can be bypassed by using the new `--force` flag
- Added clear messaging about the deletion being permanent

### How to test?

1. Try deleting a snippet without the force flag: `cargo run -- delete my-snippet`
   - You should see a confirmation prompt asking if you're sure
   - Selecting "no" should cancel the deletion
   - Selecting "yes" should delete the snippet

2. Try deleting a snippet with the force flag: `cargo run -- delete my-snippet --force` or `cargo run -- delete my-snippet -f`
   - The snippet should be deleted immediately without any confirmation

### Why make this change?

This change prevents accidental deletion of snippets by requiring explicit confirmation from users. The force flag provides a way to maintain efficiency for users who want to skip the confirmation step in scripts or when they're certain about the deletion.