### PR TITLE
Adds a tag property for advanced filtering

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -16,7 +16,10 @@ pub enum Commands {
     Run {
         name: String,
     },
-    List,
+    List {
+        #[arg(long)]
+        tag: Option<String>,
+    },
     Show {
         name: String,
     },

--- a/src/commands/edit.rs
+++ b/src/commands/edit.rs
@@ -82,4 +82,5 @@ fn apply_edits(original: &mut Snippet, edited: PartialSnippet) {
     original.content = edited.content;
     original.executable = edited.executable;
     original.updated_at = chrono::Utc::now();
+    original.tags = edited.tags;
 }

--- a/src/commands/helper.rs
+++ b/src/commands/helper.rs
@@ -27,5 +27,6 @@ pub fn redact_snippet(snippet: &Snippet) -> PartialSnippet {
         description: snippet.description.clone(),
         content: snippet.content.clone(),
         executable: snippet.executable,
+        tags: snippet.tags.clone(),
     }
 }

--- a/src/commands/list.rs
+++ b/src/commands/list.rs
@@ -1,7 +1,14 @@
 use crate::{models::SnippetStore, storage};
 use comfy_table::{Cell, Color, Row, Table, presets::UTF8_FULL};
 
-pub fn list_command() -> () {
+pub fn list_command(tag: Option<String>) -> () {
+    match tag {
+        Some(t) => output_tagged_snippets(&t),
+        None => output_all_snippets(),
+    }
+}
+
+fn output_all_snippets() -> () {
     match storage::get_snippets() {
         Some(store) => {
             let table = build_output_table(store);
@@ -9,6 +16,18 @@ pub fn list_command() -> () {
         }
         None => {
             println!("📭 No snippets saved yet.");
+        }
+    }
+}
+
+fn output_tagged_snippets(tag: &str) -> () {
+    match storage::get_snippets_by_tag(tag) {
+        Some(store) => {
+            let table = build_output_table(store);
+            println!("{table}");
+        }
+        None => {
+            println!("📭 No snippets found for tag: {}.", tag);
         }
     }
 }
@@ -29,6 +48,7 @@ fn build_output_table(store: SnippetStore) -> Table {
         Cell::new("Executable").fg(header_color),
         Cell::new("Created at").fg(header_color),
         Cell::new("Updated at").fg(header_color),
+        Cell::new("Tags").fg(header_color),
     ]);
 
     for snippet in store.snippets {
@@ -38,6 +58,7 @@ fn build_output_table(store: SnippetStore) -> Table {
             Cell::new(if snippet.executable { "yes" } else { "no" }).fg(Color::White),
             Cell::new(snippet.created_at).fg(Color::White),
             Cell::new(snippet.updated_at).fg(Color::White),
+            Cell::new(snippet.tags.join(", ")).fg(Color::White),
         ]));
     }
 

--- a/src/commands/save.rs
+++ b/src/commands/save.rs
@@ -18,12 +18,14 @@ pub fn save_command(name: String) -> () {
     let description = read_description_input();
     let executable = read_executable_input();
     let content = read_content_input();
+    let tags = read_tag_input();
     let now = Utc::now();
     let entry = Snippet {
         name,
         description,
         content,
         executable,
+        tags,
         created_at: now,
         updated_at: now,
     };
@@ -76,4 +78,18 @@ fn read_content_input() -> String {
     }
 
     content
+}
+
+fn read_tag_input() -> Vec<String> {
+    print!("🏷️  Enter tags (comma-separated, optional): ");
+    io::stdout().flush().unwrap();
+
+    let mut tags_input = String::new();
+    io::stdin().read_line(&mut tags_input).unwrap();
+
+    tags_input
+        .split(',')
+        .map(|t| t.trim().to_string())
+        .filter(|t| !t.is_empty())
+        .collect()
 }

--- a/src/commands/show.rs
+++ b/src/commands/show.rs
@@ -9,4 +9,5 @@ pub fn show_command(name: String) {
     println!("🕒 Created at: {}", snippet.created_at);
     println!("🕒 Updated at: {}", snippet.updated_at);
     println!("📋 Content:\n{}", snippet.content);
+    println!("🏷️ Tags: {}", snippet.tags.join(", "));
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,8 +19,8 @@ fn main() {
         Commands::Run { name } => {
             run::run_command(name);
         }
-        Commands::List => {
-            list::list_command();
+        Commands::List { tag } => {
+            list::list_command(tag);
         }
         Commands::Show { name } => {
             show::show_command(name);

--- a/src/models.rs
+++ b/src/models.rs
@@ -7,6 +7,7 @@ pub struct Snippet {
     pub description: String,
     pub content: String,
     pub executable: bool,
+    pub tags: Vec<String>,
     #[serde(default = "default_now")]
     pub created_at: DateTime<Utc>,
     #[serde(default = "default_now")]
@@ -17,7 +18,7 @@ fn default_now() -> DateTime<Utc> {
     Utc::now()
 }
 
-#[derive(Serialize, Deserialize, Default)]
+#[derive(Serialize, Deserialize, Default, Debug)]
 pub struct SnippetStore {
     pub snippets: Vec<Snippet>,
 }
@@ -28,4 +29,5 @@ pub struct PartialSnippet {
     pub description: String,
     pub content: String,
     pub executable: bool,
+    pub tags: Vec<String>,
 }

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -63,6 +63,23 @@ pub fn get_snippets_by_name(query: &str) -> Option<Vec<Snippet>> {
         .collect()
 }
 
+pub fn get_snippets_by_tag(tag: &str) -> Option<SnippetStore> {
+    let store = get_snippets()?;
+
+    let matching: Vec<Snippet> = store
+        .snippets
+        .iter()
+        .filter(|s| s.tags.iter().any(|t| t.eq_ignore_ascii_case(tag)))
+        .cloned()
+        .collect();
+
+    if matching.is_empty() {
+        None
+    } else {
+        Some(SnippetStore { snippets: matching })
+    }
+}
+
 pub fn write_snippets(store: &SnippetStore) -> Result<(), Box<dyn std::error::Error>> {
     let path = get_storage_path();
     let file = File::create(&path)?;


### PR DESCRIPTION
### TL;DR

Added tag support for snippets, allowing users to organize and filter their snippets by tags.

### What changed?

- Added a `tags` field to the `Snippet` and `PartialSnippet` structs
- Enhanced the `List` command to accept an optional `--tag` parameter to filter snippets
- Added tag input during snippet creation with the `save_command`
- Updated the `edit` command to preserve tags when editing snippets
- Added tag display in the `show` command output
- Added a new column for tags in the list table output
- Implemented a new `get_snippets_by_tag` function in the storage module

### How to test?

1. Create a new snippet with tags:
   ```
   snip save my-snippet
   # When prompted for tags, enter: "important, reference"
   ```

2. List all snippets:
   ```
   cargo run -- list
   ```

3. Filter snippets by tag:
   ```
   cargo run -- list --tag important
   ```

4. View a snippet with tags:
   ```
   cargo run -- show my-snippet
   ```

5. Edit a snippet and update its tags

### Why make this change?

Tags provide a flexible way to organize snippets beyond just naming conventions. This allows users to categorize snippets and quickly filter them based on their purpose, language, project, or any other relevant attribute. The tag-based filtering makes it easier to manage larger collections of snippets.