### PR TITLE
Adds export command

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -34,4 +34,7 @@ pub enum Commands {
     Edit {
         name: String,
     },
+    Export {
+        path: String,
+    },
 }

--- a/src/commands/export.rs
+++ b/src/commands/export.rs
@@ -1,0 +1,20 @@
+use crate::storage;
+use std::{fs::File, path::Path};
+
+pub fn export_command(file_path: &str) {
+    let Some(store) = storage::get_snippets() else {
+        println!("📭 No snippets to export.");
+        return;
+    };
+
+    match File::create(Path::new(file_path)) {
+        Ok(file) => {
+            if let Err(err) = serde_yaml::to_writer(file, &store) {
+                eprintln!("⛔ Failed to write YAML: {err}");
+            } else {
+                println!("📦 Snippets exported to {file_path}");
+            }
+        }
+        Err(err) => eprintln!("⛔ Failed to create export file: {err}"),
+    }
+}

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1,6 +1,7 @@
 pub mod copy;
 pub mod delete;
 pub mod edit;
+pub mod export;
 pub mod helper;
 pub mod list;
 pub mod run;

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,7 +7,7 @@ mod ui;
 use clap::Parser;
 use cli::{Cli, Commands};
 
-use crate::commands::{copy, delete, edit, list, run, save, show};
+use crate::commands::{copy, delete, edit, export, list, run, save, show};
 
 fn main() {
     let args = Cli::parse();
@@ -33,6 +33,9 @@ fn main() {
         }
         Commands::Edit { name } => {
             edit::edit_command(name);
+        }
+        Commands::Export { path } => {
+            export::export_command(&path);
         }
     }
 }


### PR DESCRIPTION
### TL;DR

Added a new `export` command to export snippets to a YAML file.

### What changed?

- Added a new `Export` variant to the `Commands` enum in `cli.rs` that accepts a file path
- Created a new module `commands/export.rs` with the implementation of the export functionality
- Added the export module to the module declarations in `commands/mod.rs`
- Updated the main command handler in `main.rs` to handle the new export command

### How to test?

1. Run the application with the export command and provide a file path:
   ```
   cargo run -- export /path/to/export.yaml
   ```
2. Verify that the snippets are correctly exported to the specified file in YAML format
3. Test edge cases:
   - Exporting when no snippets exist
   - Exporting to a path with insufficient permissions
   - Exporting to an invalid path

### Why make this change?

This change enables users to export their snippets to a YAML file, which provides a way to back up snippets or transfer them between different environments. This enhances the utility of the application by allowing users to persist and share their snippets outside of the application's internal storage.