### PR TITLE
Adds import command

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -37,4 +37,7 @@ pub enum Commands {
     Export {
         path: String,
     },
+    Import {
+        path: String,
+    },
 }

--- a/src/commands/import.rs
+++ b/src/commands/import.rs
@@ -1,0 +1,36 @@
+use crate::{models::SnippetStore, storage};
+use std::{fs::File, path::Path};
+
+pub fn import_command(file_path: &str) {
+    let file = match File::open(Path::new(file_path)) {
+        Ok(f) => f,
+        Err(err) => {
+            eprintln!("⛔ Failed to open import file: {err}");
+            return;
+        }
+    };
+
+    let imported: SnippetStore = match serde_yaml::from_reader(file) {
+        Ok(s) => s,
+        Err(err) => {
+            eprintln!("⛔ Failed to parse YAML: {err}");
+            return;
+        }
+    };
+
+    let mut store = storage::get_snippets().unwrap_or_default();
+
+    let mut added = 0;
+    for snippet in imported.snippets {
+        if !store.snippets.iter().any(|s| s.name == snippet.name) {
+            store.snippets.push(snippet);
+            added += 1;
+        }
+    }
+
+    if let Err(err) = storage::write_snippets(&store) {
+        eprintln!("⛔ Failed to update storage: {err}");
+    } else {
+        println!("📥 Imported {added} new snippet(s) from {file_path}");
+    }
+}

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -3,6 +3,7 @@ pub mod delete;
 pub mod edit;
 pub mod export;
 pub mod helper;
+pub mod import;
 pub mod list;
 pub mod run;
 pub mod save;

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,7 +7,7 @@ mod ui;
 use clap::Parser;
 use cli::{Cli, Commands};
 
-use crate::commands::{copy, delete, edit, export, list, run, save, show};
+use crate::commands::{copy, delete, edit, export, import, list, run, save, show};
 
 fn main() {
     let args = Cli::parse();
@@ -36,6 +36,9 @@ fn main() {
         }
         Commands::Export { path } => {
             export::export_command(&path);
+        }
+        Commands::Import { path } => {
+            import::import_command(&path);
         }
     }
 }


### PR DESCRIPTION
### TL;DR

Added a new import command to allow importing snippets from YAML files.

### What changed?

- Added a new `Import` command to the CLI enum in `cli.rs`
- Created a new `import.rs` module with the implementation of the import functionality
- Added the import module to the module exports in `commands/mod.rs`
- Updated the main command handler in `main.rs` to handle the new import command

The import command reads a YAML file, parses it into a `SnippetStore`, and adds any snippets that don't already exist in the current store.

### How to test?

1. Export your snippets to a file: `cargo run -- export snippets.yaml`
2. Import the snippets: `cargo run -- import snippets.yaml`
3. Verify that the import command reports the number of snippets imported
4. Try importing the same file again and verify that no duplicates are created

### Why make this change?

This feature complements the existing export functionality, creating a complete import/export system that allows users to:
- Back up their snippets
- Share snippets between different machines
- Restore snippets from backups
- Import snippets shared by other users

The import functionality is designed to be safe by avoiding duplicate snippets, making it convenient for users to merge snippet collections.