### PR TITLE
Changes return type to make it consistent

### DIFF
--- a/src/commands/helper.rs
+++ b/src/commands/helper.rs
@@ -4,7 +4,7 @@ use crate::{
 };
 
 pub fn get_snippet(name: String) -> Option<Snippet> {
-    let snippets = match storage::get_snippets_by_name(&name) {
+    let store = match storage::get_snippets_by_name(&name) {
         Some(s) => s,
         None => {
             println!("⛔ Snippet '{}' not found.", name);
@@ -12,7 +12,7 @@ pub fn get_snippet(name: String) -> Option<Snippet> {
         }
     };
 
-    return match ui::select_snippet(snippets) {
+    return match ui::select_snippet(store.snippets) {
         Some(s) => Some(s),
         None => {
             println!("⛔ Snippet '{}' not found.", name);

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -41,7 +41,7 @@ pub fn get_snippets() -> Option<SnippetStore> {
     Some(store)
 }
 
-pub fn get_snippets_by_name(query: &str) -> Option<Vec<Snippet>> {
+pub fn get_snippets_by_name(query: &str) -> Option<SnippetStore> {
     let store = get_snippets()?;
 
     let names: Vec<&str> = store.snippets.iter().map(|s| s.name.as_str()).collect();
@@ -50,9 +50,9 @@ pub fn get_snippets_by_name(query: &str) -> Option<Vec<Snippet>> {
     let matches = Pattern::parse(query, CaseMatching::Ignore, Normalization::Smart)
         .match_list(&names, &mut matcher);
 
-    matches
+    let matched_snippets: Vec<Snippet> = matches
         .into_iter()
-        .map(|(matched_name, _)| {
+        .filter_map(|(matched_name, _)| {
             let matched_str = *matched_name;
             store
                 .snippets
@@ -60,7 +60,15 @@ pub fn get_snippets_by_name(query: &str) -> Option<Vec<Snippet>> {
                 .find(|s| s.name == matched_str)
                 .cloned()
         })
-        .collect()
+        .collect();
+
+    if matched_snippets.is_empty() {
+        None
+    } else {
+        Some(SnippetStore {
+            snippets: matched_snippets,
+        })
+    }
 }
 
 pub fn get_snippets_by_tag(tag: &str) -> Option<SnippetStore> {


### PR DESCRIPTION
### TL;DR

Refactored the snippet search functionality to return a `SnippetStore` instead of a `Vec<Snippet>`.

### What changed?

- Modified `get_snippets_by_name()` to return `Option<SnippetStore>` instead of `Option<Vec<Snippet>>`
- Updated the function to properly handle empty results by returning `None`
- Changed `map()` to `filter_map()` to handle potential missing snippets
- Updated the `helper.rs` file to work with the new return type by accessing the `snippets` field

### How to test?

1. Search for snippets using a query that should return results
2. Search for snippets using a query that shouldn't return any results
3. Verify that both cases work correctly and display appropriate messages

### Why make this change?

This change improves consistency in the codebase by ensuring that snippet search functions return the same type (`SnippetStore`). It also improves error handling by properly checking for empty results and returning `None` in those cases, which allows the UI to display appropriate error messages.