### PR TITLE
Adds restore command

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -40,4 +40,5 @@ pub enum Commands {
     Import {
         path: String,
     },
+    Restore,
 }

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -5,6 +5,7 @@ pub mod export;
 pub mod helper;
 pub mod import;
 pub mod list;
+pub mod restore;
 pub mod run;
 pub mod save;
 pub mod show;

--- a/src/commands/restore.rs
+++ b/src/commands/restore.rs
@@ -1,0 +1,23 @@
+use crate::storage::{get_backup_files, restore_backup};
+use crate::ui::select_backup;
+
+pub fn restore_command() {
+    let backups = get_backup_files();
+    if backups.is_empty() {
+        println!("📭 No backups found.");
+        return;
+    }
+
+    let display_names: Vec<String> = backups
+        .iter()
+        .map(|p| p.file_name().unwrap().to_string_lossy().to_string())
+        .collect();
+
+    let selected_index = match select_backup(&display_names) {
+        Some(i) => i,
+        None => return,
+    };
+
+    let full_path = backups.get(selected_index).unwrap().clone();
+    restore_backup(full_path);
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,7 +7,7 @@ mod ui;
 use clap::Parser;
 use cli::{Cli, Commands};
 
-use crate::commands::{copy, delete, edit, export, import, list, run, save, show};
+use crate::commands::{copy, delete, edit, export, import, list, restore, run, save, show};
 
 fn main() {
     let args = Cli::parse();
@@ -39,6 +39,9 @@ fn main() {
         }
         Commands::Import { path } => {
             import::import_command(&path);
+        }
+        Commands::Restore => {
+            restore::restore_command();
         }
     }
 }

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -18,3 +18,12 @@ pub fn select_snippet(matches: Vec<Snippet>) -> Option<Snippet> {
 
     matches.get(selection).cloned()
 }
+
+pub fn select_backup(backups: &[String]) -> Option<usize> {
+    Select::with_theme(&ColorfulTheme::default())
+        .with_prompt("📦 Select a backup to restore:")
+        .items(backups)
+        .default(0)
+        .interact()
+        .ok()
+}


### PR DESCRIPTION
# Add Restore Command for Backups

### TL;DR

Added a new `restore` command that allows users to select and restore from previous backups.

### What changed?

- Added a new `Restore` command to the CLI options
- Created a new `restore.rs` module with the restore command implementation
- Added functions in `storage.rs` to get backup files and restore from a backup
- Added a UI function to select a backup from a list
- Integrated the restore command into the main command router

### How to test?

1. Run `cargo run -- restore` to see a list of available backups
2. Select a backup from the interactive list
3. Verify that the backup has been restored successfully
4. Try when no backups exist to see the "No backups found" message

### Why make this change?

This feature provides users with a way to recover their snippets from previous backups, which is essential for data recovery in case of accidental deletions or modifications. The interactive selection makes it easy to choose the right backup without having to manually navigate the file system.