### PR TITLE
Adds more descriptive help messages

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -10,35 +10,41 @@ pub struct Cli {
 
 #[derive(Subcommand)]
 pub enum Commands {
-    Save {
-        name: String,
-    },
-    Run {
-        name: String,
-    },
+    #[command(about = "Save a new snippet interactively")]
+    Save { name: String },
+
+    #[command(about = "List all saved snippets (optionally filter by tag)")]
     List {
-        #[arg(long)]
+        #[arg(short, long, help = "Filter by tag")]
         tag: Option<String>,
     },
-    Show {
-        name: String,
-    },
-    Copy {
-        name: String,
-    },
+
+    #[command(about = "Show the full content of a snippet")]
+    Show { name: String },
+
+    #[command(about = "Run a saved snippet")]
+    Run { name: String },
+
+    #[command(about = "Edit a saved snippet in your default editor")]
+    Edit { name: String },
+
+    #[command(about = "Delete a snippet with confirmation prompt")]
     Delete {
         name: String,
-        #[arg(short, long)]
+
+        #[arg(short, long, help = "Force delete without confirmation")]
         force: bool,
     },
-    Edit {
-        name: String,
-    },
-    Export {
-        path: String,
-    },
-    Import {
-        path: String,
-    },
+
+    #[command(about = "Copy a snippet's content to the clipboard")]
+    Copy { name: String },
+
+    #[command(about = "Export all snippets to a YAML file")]
+    Export { path: String },
+
+    #[command(about = "Import snippets from a YAML file")]
+    Import { path: String },
+
+    #[command(about = "Restore a previous backup")]
     Restore,
 }


### PR DESCRIPTION
### TL;DR

Improved CLI command documentation with descriptive help text for all subcommands and arguments.

### What changed?

- Added `#[command(about = "...")]` attributes to all subcommands with descriptive text explaining their purpose
- Added helpful descriptions to command arguments using `help = "..."` attributes
- Reorganized the command order to group related commands together
- Formatted the code more consistently with proper spacing between command groups

### How to test?

1. Run the application with `--help` flag to see the improved command descriptions
2. Try individual commands with `--help` (e.g., `save --help`, `list --help`) to verify the argument descriptions
3. Verify that all commands still function as expected

### Why make this change?

This change enhances the user experience by providing clear, descriptive help text for all commands and arguments. Users will better understand the purpose of each command and how to use them correctly without needing to consult external documentation.