### PR TITLE
Adds metadata to toml

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -200,22 +200,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b94f61472cee1439c0b966b47e3aca9ae07e45d070759512cd390ea2bebc6675"
 
 [[package]]
-name = "cli-snippet-manager"
-version = "0.1.0"
-dependencies = [
- "arboard",
- "chrono",
- "clap",
- "comfy-table",
- "dialoguer",
- "dirs",
- "nucleo-matcher",
- "serde",
- "serde_yaml",
- "tempfile",
-]
-
-[[package]]
 name = "clipboard-win"
 version = "5.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -551,6 +535,22 @@ name = "log"
 version = "0.4.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
+
+[[package]]
+name = "markit"
+version = "0.1.0"
+dependencies = [
+ "arboard",
+ "chrono",
+ "clap",
+ "comfy-table",
+ "dialoguer",
+ "dirs",
+ "nucleo-matcher",
+ "serde",
+ "serde_yaml",
+ "tempfile",
+]
 
 [[package]]
 name = "memchr"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,10 @@
 [package]
-name = "cli-snippet-manager"
+name = "markit"
 version = "0.1.0"
 edition = "2024"
+description = "A terminal snippet manager."
+license = "MIT"
+repository = "https://github.com/Nightstack/cli-snippet-manager"
 
 [dependencies]
 clap = { version = "4", features = ["derive"] }
@@ -14,3 +17,7 @@ dialoguer = "0.11"
 arboard = "3.3"
 tempfile = "3.20.0"
 chrono = { version = "0.4", features = ["serde"] }
+
+[[bin]]
+name = "markit"
+path = "src/main.rs"


### PR DESCRIPTION
### TL;DR

Renamed the project from "cli-snippet-manager" to "markit" and added package metadata.

### What changed?

- Renamed the package from "cli-snippet-manager" to "markit" in both Cargo.toml and Cargo.lock
- Added package metadata:
  - Description: "A terminal snippet manager."
  - License: "MIT"
  - Repository URL: "https://github.com/Nightstack/cli-snippet-manager"
- Added binary configuration to specify the executable name as "markit"

### How to test?

1. Build the project with `cargo build`
2. Verify the binary is named "markit"
3. Check that `cargo package` works correctly with the new metadata

### Why make this change?

This change establishes a more concise and memorable name for the project ("markit") while adding necessary metadata for publishing to crates.io. The binary configuration ensures the executable name matches the package name for consistency.